### PR TITLE
Add server message handling to dblib

### DIFF
--- a/src/dblib.ml
+++ b/src/dblib.ml
@@ -31,6 +31,7 @@ type severity =
   | CONSISTENCY
 
 exception Error of severity * string
+exception Message of string
 
 let err_handler (f: severity -> int -> string -> unit) =
   Callback.register "Freetds.Dblib.err_handler" f
@@ -38,12 +39,18 @@ let err_handler (f: severity -> int -> string -> unit) =
 let default_err_handler severity _err msg =
   raise(Error(severity, msg))
 
+let msg_handler (f: string -> unit) =
+  Callback.register "Freetds.Dblib.msg_handler" f
+
+let default_msg_handler msg = raise(Message(msg))
+
 external dbinit : unit -> unit = "ocaml_freetds_dbinit"
 
 let () =
   Callback.register_exception "Freetds.Dblib.Error"
                               (Error(FATAL, "message"));
   err_handler default_err_handler;
+  msg_handler default_msg_handler;
   dbinit()
   (* One must call this function before trying to use db-lib in any
      way.  Allocates various internal structures and reads

--- a/src/dblib.mli
+++ b/src/dblib.mli
@@ -176,11 +176,19 @@ exception Error of severity * string
     can change the reaction to some errors by installing your own
     handler with {!err_handler}. *)
 
+exception Message of string
+(** [Message(message)] is raised when a message is sent from the server
+    (e.g. malformed SQL). *)
+
 val err_handler : (severity -> int -> string -> unit) -> unit
 (** [err_handler f] installs [f] as the default error handler for
     non-OS related errors and errors not coming from the server.  [f]
     is given the {!severity}, the number of the error (see the 400 or
     so error numbers sybdb.h, macros SYBE...) and the message. *)
+
+val msg_handler : (string -> unit) -> unit
+(** [msg_handler f] installs [f] as the default message handler for
+    messages coming from the server. [f] is given the message. *)
 
 val settime : int -> unit
 (** [settime seconds] Set the number of seconds that DB-Library will

--- a/src/dblib.mli
+++ b/src/dblib.mli
@@ -176,19 +176,16 @@ exception Error of severity * string
     can change the reaction to some errors by installing your own
     handler with {!err_handler}. *)
 
-exception Message of string
-(** [Message(message)] is raised when a message is sent from the server
-    (e.g. malformed SQL). *)
-
 val err_handler : (severity -> int -> string -> unit) -> unit
 (** [err_handler f] installs [f] as the default error handler for
     non-OS related errors and errors not coming from the server.  [f]
     is given the {!severity}, the number of the error (see the 400 or
     so error numbers sybdb.h, macros SYBE...) and the message. *)
 
-val msg_handler : (string -> unit) -> unit
+val msg_handler : (severity -> int -> string -> unit) -> unit
 (** [msg_handler f] installs [f] as the default message handler for
-    messages coming from the server. [f] is given the message. *)
+    messages coming from the server. [f] is given the {!severity}, the line
+    number, and the message. *)
 
 val settime : int -> unit
 (** [settime seconds] Set the number of seconds that DB-Library will


### PR DESCRIPTION
Handles error messages from the server and raises them as errors. For example, if we execute this SQL:

```
SELECT 1
FROM (*$#
```

We get:

> Freetds.Dblib.Error(9, "Error on line 2: Incorrect syntax near '*'.")
