### PR TITLE
Adds required autotools to opam external deps

### DIFF
--- a/freetds.opam
+++ b/freetds.opam
@@ -30,9 +30,9 @@ depends: [
   "ocamlfind" {build}
 ]
 depexts: [
-  [["centos"] ["freetds-devel"]]
-  [["debian"] ["freetds-dev"]]
-  [["fedora"] ["freetds-devel"]]
-  [["ubuntu"] ["freetds-dev"]]
-  [["osx" "homebrew"] ["freetds"]]
+  [["centos"] ["autoconf" "automake" "freetds-devel"]]
+  [["debian"] ["autoconf" "automake" "freetds-dev"]]
+  [["fedora"] ["autoconf" "automake" "freetds-devel"]]
+  [["ubuntu"] ["autoconf" "automake" "freetds-dev"]]
+  [["osx" "homebrew"] ["autoconf" "automake" "freetds"]]
 ]


### PR DESCRIPTION
When building using the .opam file one of the scripts that gets ran is
the `autogen.sh` file which relies upon the autoconf and automake
autotools.