### PR TITLE
Improve TravisCI build and add OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
+addons:
+  apt:
+    sources:
+      - avsm
+    packages:
+      - freetds-dev
+      - ocaml
+      - opam
+sudo: false
 language: c
+os:
+  - linux
+  - osx
 install: bash -ex .travis/install.sh
-script: ./autogen.sh && ./configure && make
+script: eval `opam config env` && ./autogen.sh && ./configure && make

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,26 +3,17 @@
 # but tried using binary packages from http://opam.ocamlpro.com/doc/Quick_Install.html
 # they seem to be down at the moment and maybe we only need ocaml-findlib that debian does have...
 
-export OPAM_PACKAGES='ocamlfind'
+if [ $TRAVIS_OS_NAME = osx ]; then
+    brew unlink python
+    brew install ocaml opam
+fi
 
-# Install OCaml
-sudo apt-get update -qq
-sudo apt-get install -qq ocaml
+# Setup opam
+opam init --auto-setup
+eval `opam config env`
 
-# Install ocaml-findlib
-sudo apt-get install -qq ocaml-findlib
-
-# Install opam
-#echo "deb http://www.recoil.org/~avsm/ wheezy main" | sudo tee -a /etc/apt/sources.list
-#sudo apt-get update
-#sudo apt-get install opam
-#opam init --auto-setup
-#eval `opam config -env`
-#popd
-
-# Install any ocaml packages
-#opam install "${OPAM_PACKAGES}"
-
-# Install freetds
-sudo apt-get install freetds-dev
-
+# Install OCaml dependencies
+opam pin add -yn freetds .
+opam install -y depext
+opam depext -y freetds
+opam install --deps-only -y freetds


### PR DESCRIPTION
  - Use faster container builds on Linux, by using `sudo: false` and
    listing apt dependencies with the special TravisCI syntax.
  - Use depext for dependencies
  - Add an OSX build