### PR TITLE
Fix build warnings

### DIFF
--- a/examples/ct_example.ml
+++ b/examples/ct_example.ml
@@ -76,9 +76,7 @@ let _ =
              ignore (results cmd)
          with
              | Cmd_fail
-             | Failure "ct_alloc"
-             | Failure "ct_command"
-             | Failure "ct_send" -> raise_messages conn);
+             | Failure _ -> raise_messages conn);
 
     debug_print (sprintf "Set database to %s\n" !database);
 

--- a/freetds.opam
+++ b/freetds.opam
@@ -14,6 +14,8 @@ tags: [
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
+available: [ ocaml-version >= "4.02.3" ]
+
 depends: [
   "jbuilder" {build & >= "1.0+beta19.1"}
 ]

--- a/src/ct_c.c
+++ b/src/ct_c.c
@@ -526,7 +526,7 @@ CAMLprim value mltds_ct_res_info(value cmd, value resinfo_type)
 CAMLprim value mltds_ct_bind( value cmd, value maxlen, value index )
 {
     CAMLparam3(cmd, maxlen, index);
-    CS_DATAFMT fmt = {0,0,0,0,0,0,0,0,0,0,0};
+    CS_DATAFMT fmt = {{0,0,0,0,0,0,0,0,0,0,0}};
     struct binding_buffer* buf = malloc(sizeof(struct binding_buffer));
     buf->fmt = fmt;
     

--- a/src/dblib.ml
+++ b/src/dblib.ml
@@ -69,7 +69,7 @@ external dbopen :
   = "ocaml_freetds_dbopen_bc" "ocaml_freetds_dbopen"
 
 let connect ?user ?password ?charset ?language ?application server =
-  dbopen ?user ?password ?charset ?language ?application ~server
+  dbopen ~user ~password ~charset ~language ~application ~server
 
 external close : dbprocess -> unit = "ocaml_freetds_dbclose"
 
@@ -84,7 +84,7 @@ external canquery :  dbprocess -> unit = "ocaml_freetds_dbcanquery"
 
 external results : dbprocess -> bool = "ocaml_freetds_dbresults"
 
-external numcols : dbprocess -> int = "ocaml_freetds_numcols" "noalloc"
+external numcols : dbprocess -> int = "ocaml_freetds_numcols" [@@noalloc]
     (** Return number of regular columns in a result set.  *)
 
 external colname : dbprocess -> int -> string = "ocaml_freetds_dbcolname"

--- a/src/dblib_stubs.c
+++ b/src/dblib_stubs.c
@@ -32,6 +32,8 @@
 #include <caml/callback.h>
 #include <caml/custom.h>
 
+static void raise_fatal(char*) __attribute__ ((noreturn));
+
 static void raise_fatal(char *msg)
 {
   CAMLparam0();
@@ -47,7 +49,6 @@ static void raise_fatal(char *msg)
   vmsg = caml_copy_string(msg);
   args[1] = vmsg;
   caml_raise_with_args(*exn, 2, args);
-  CAMLreturn0;
 }
 
 static int convert_severity(int severity)


### PR DESCRIPTION
 - We were calling optional arguments with ? instead of ~
 - Add braces around an initialization
 - Change "noalloc" to [@@noalloc] since annotations were introduced
   in OCaml 4.02 and jbuilder/Dune requires >= 4.02.3 anyway
 - Add a requirement for OCaml >= 4.02.3
 - Mark raise_fatal as noreturn