### PR TITLE
Add unit tests

### DIFF
--- a/freetds.opam
+++ b/freetds.opam
@@ -16,6 +16,7 @@ build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta19.1"}
+  "ounit" {test & >= "2.0.0"}
 ]
 
 depexts: [

--- a/src/dblib_stubs.c
+++ b/src/dblib_stubs.c
@@ -532,7 +532,10 @@ CAMLexport value ocaml_freetds_dbnextrow(value vdbproc)
 CAMLexport value ocaml_freetds_dbcount(value vdbproc)
 {
   CAMLparam1(vdbproc);
-  CAMLreturn(Val_int(DBPROCESS_VAL(vdbproc)));
+  CAMLlocal1(vcount);
+  DBPROCESS *dbproc = DBPROCESS_VAL(vdbproc);
+  vcount = dbcount(dbproc);
+  CAMLreturn(Val_int(vcount));
 }
 
 

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,0 +1,10 @@
+(jbuild_version 1)
+
+(executables
+ ((names (test_dblib))
+  (libraries (freetds oUnit))))
+
+(alias
+ ((name runtest)
+  (deps (test_dblib.exe))
+ (action (run ${<}))))

--- a/test/test_dblib.ml
+++ b/test/test_dblib.ml
@@ -1,0 +1,65 @@
+open Freetds
+open OUnit2
+open Printf
+
+let string_of_string s = s
+
+let get_params () =
+  [ "USER" ; "PASSWORD" ; "SERVER" ; "DATABASE" ]
+  |> List.map (fun suffix ->
+      let env_var = sprintf "MSSQL_TEST_%s" suffix in
+      try
+        Some (Sys.getenv env_var)
+      with Not_found ->
+        None)
+  |> function
+  | [ Some user ; Some password ; Some server ; Some database ] ->
+    Some (user, password, server, database)
+  | _ ->
+    None
+
+let with_conn (user, password, server, database) f =
+  let conn = Dblib.connect ~user ~password server in
+  Dblib.use conn database;
+  try
+    f conn;
+    Dblib.close conn
+  with e ->
+    Dblib.close conn;
+    raise e
+
+let test_connect ((_, _, _, database) as params) _ =
+  with_conn params (fun conn ->
+      Dblib.name conn
+      |> assert_equal ~printer:string_of_string database)
+
+let test_basic_query params _ =
+  with_conn params (fun conn ->
+      Dblib.sqlexec conn "SELECT CAST(1 AS INT) AS test";
+      Dblib.results conn
+      |> assert_bool "query has results";
+      Dblib.numcols conn
+      |> assert_equal ~printer:string_of_int 1;
+      Dblib.colname conn 1
+      |> assert_equal ~printer:string_of_string "test";
+      Dblib.coltype conn 1
+      |> assert_equal ~printer:Dblib.string_of_col_type Dblib.SYBINT4;
+      Dblib.nextrow conn
+      |> assert_equal [ Dblib.INT 1 ];
+      assert_raises Not_found (fun () -> Dblib.nextrow conn);
+      Dblib.results conn
+      |> assert_equal ~printer:string_of_bool false;
+      Dblib.count conn
+      |> assert_equal ~printer:string_of_int 1)
+
+let () =
+  match get_params () with
+  | None ->
+    print_endline "Skipping tests since MSSQL_TEST_* environment variables \
+                   aren't set"
+  | Some params ->
+    [ "connect", test_connect
+    ; "basic query", test_basic_query ]
+    |> List.map (fun (name, test) -> name >:: test params)
+    |> test_list
+    |> run_test_tt_main


### PR DESCRIPTION
This adds some unit tests when we have a database to run them
against. I've been running them locally but I don't really know how
to configure them with Travis CI (there's probably a way we can
run the MSSQL Docker image?).

This caught a bug where Dblib.count wasn't actually calling
dbcount.