### PR TITLE
Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
-addons:
-  apt:
-    sources:
-      - avsm
-    packages:
-      - freetds-dev
-      - ocaml
-      - opam
-sudo: false
 language: c
-os:
-  - linux
-  - osx
-install: bash -ex .travis/install.sh
-script: opam config exec -- make
+sudo: false
+services:
+  - docker
+install: bash -ex ./.travis/install.sh
+script: bash -ex ./.travis/build.sh
+env:
+  global:
+    - PACKAGE="freetds"
+    - EXTRA_DEPS="ounit"
+matrix:
+  include:
+    - os: linux
+      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.02.3"
+    - os: linux
+      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"
+    - os: linux
+      env: DISTRO="alpine-3.5" OCAML_VERSION="4.04.2"
+    - os: linux
+      env: DISTRO="debian-unstable" OCAML_VERSION="4.05.0"
+    - os: linux
+      env: DISTRO="debian-testing" OCAML_VERSION="4.06.0"
+    - os: osx

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+if [[ "$TRAVIS_OS_NAME" = osx ]]; then
+    eval `opam config env`
+    make
+    make test
+else
+    bash -ex ./.travis-docker.sh
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,20 +1,13 @@
-# Hacking the build into Travis-CI "C" environment
-# based on http://blog.mlin.net/2013/02/testing-ocaml-projects-on-travis-ci.html
-# but tried using binary packages from http://opam.ocamlpro.com/doc/Quick_Install.html
-# they seem to be down at the moment and maybe we only need ocaml-findlib that debian does have...
-export OPAM_PACKAGES='jbuilder'
-
 if [ $TRAVIS_OS_NAME = osx ]; then
     brew unlink python
     brew install ocaml opam
+    opam init --auto-setup
+    eval `opam config env`
+    opam pin add -yn "$PACKAGE" .
+    opam install -y depext
+    opam depext -y "$PACKAGE"
+    opam install --deps-only -y "$PACKAGE"
+    opam install -y "$EXTRA_DEPS"
+else
+    wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
 fi
-
-# Setup opam
-opam init --auto-setup
-eval `opam config env`
-
-# Install OCaml dependencies
-opam pin add -yn freetds .
-opam install -y depext
-opam depext -y freetds
-opam install --deps-only -y freetds

--- a/freetds.opam
+++ b/freetds.opam
@@ -1,5 +1,6 @@
 opam-version: "1.2"
 
+authors: ["Christophe.Troestler@umons.ac.be"]
 maintainer: "Christophe.Troestler@umons.ac.be"
 homepage: "https://github.com/kennknowles/ocaml-freetds"
 dev-repo: "https://github.com/kennknowles/ocaml-freetds.git"

--- a/freetds.opam
+++ b/freetds.opam
@@ -19,6 +19,7 @@ depends: [
 ]
 
 depexts: [
+  [["alpine"] ["freetds-dev"]]
   [["centos"] ["freetds-devel"]]
   [["debian"] ["freetds-dev"]]
   [["fedora"] ["freetds-devel"]]


### PR DESCRIPTION
This makes Travis CI build on various Linux distros and OCaml versions using Docker.

I also fixed two problems I found this way (missing Alpine depext and `opam lint` not passing).