### PR TITLE
Re-run tests when you run `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ install:
 	@jbuilder install
 
 test:
-	@jbuilder runtest
+	@jbuilder runtest --force
 
 .PHONY: all build clean install test


### PR DESCRIPTION
By default, jbuilder only runs a target once unless dependencies
change, but we want `make test` to always run the tests.