### PR TITLE
Release the OCaml lock during IO

### DIFF
--- a/test/jbuild
+++ b/test/jbuild
@@ -2,7 +2,7 @@
 
 (executables
  ((names (test_dblib test_ct))
-  (libraries (freetds oUnit))))
+  (libraries (freetds oUnit threads))))
 
 (alias
  ((name test)

--- a/test/test_dblib.ml
+++ b/test/test_dblib.ml
@@ -28,8 +28,9 @@ let with_conn (user, password, server, database) f =
   let conn = Dblib.connect ~user ~password server in
   Dblib.use conn database;
   try
-    f conn;
-    Dblib.close conn
+    let res = f conn in
+    Dblib.close conn;
+    res
   with e ->
     Dblib.close conn;
     raise e
@@ -135,6 +136,47 @@ let test_insert params _ =
            Dblib.([STRING ""; INT 0; STRING ""; INT(-1); FLOAT(-6.3)]);
     )
 
+let test_concurrency params _ =
+  let jobs = ref [] in
+  for _ = 0 to 50 do
+    let result = ref (Error (Failure "result was never set")) in
+    let job =
+      Thread.create (fun () ->
+          result :=
+            try
+              with_conn params (fun conn ->
+                  Dblib.sqlexec conn "SELECT 1, 2, 3";
+                  Dblib.results conn
+                  |> assert_bool "query has results";
+                  Dblib.nextrow conn
+                  |> assert_equal ~printer:string_of_row
+                    Dblib.([INT 1; INT 2; INT 3]);
+                  Dblib.canquery conn;
+                  (try
+                     ignore(Dblib.coltype conn 4);
+                     assert_failure "Dblib.coltype should signal '4' is not a valid column"
+                   with
+                   | Dblib.Error(Dblib.PROGRAM, _) -> ()
+                   | e -> assert_failure("Dblib.coltype should raise Error(PROGRAM, _) \
+                                          instead of " ^ Printexc.to_string e));
+                  (try
+                     Dblib.sqlexec conn "not real sql";
+                   with
+                   | Dblib.Error(Dblib.FATAL, _) -> ()
+                   | e -> assert_failure("Dblib.sqlexec should raise Error(FATAL, _) \
+                                          instead of " ^ Printexc.to_string e));
+                  Ok ())
+            with exn ->
+              Printexc.print_backtrace stderr;
+              Error exn)
+        ()
+    in
+    jobs := (job, result) :: !jobs
+  done;
+  List.iter (fun (job, result) ->
+      Thread.join job;
+      assert_equal (Ok ()) !result) !jobs
+
 let () =
   match get_params () with
   | None ->
@@ -145,7 +187,8 @@ let () =
      ; "basic query", test_basic_query
      ; "empty strings", test_empty_strings
      ; "data", test_data
-     ; "insert", test_insert ]
+     ; "insert", test_insert
+     ; "concurrency", test_concurrency ]
      |> List.map (fun (name, test) -> name >:: test params)
      |> OUnit2.test_list
      |> OUnit2.run_test_tt_main


### PR DESCRIPTION
This releases OCaml's runtime lock whenever we call C functions that do
IO. It should allow users of this to run ocaml-freetds in parallel, or
when using Async/Lwt.

I had to re-arrange some code to avoid calling any OCaml functions
while the lock was released.