### PR TITLE
Remove --dev from dune build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 build:
-	@jbuilder build @install @test --dev
+	@jbuilder build @install @test
 
 clean:
 	@jbuilder clean


### PR DESCRIPTION
```
dune: --dev is no longer accepted as it is now the default.
Usage: dune build [OPTION]... [TARGET]...
Try `dune build --help' or `dune --help' for more information.
make: *** [Makefile:4: build] Error 1
```